### PR TITLE
chore(pr-title): update to node16

### DIFF
--- a/pr-title/action.yml
+++ b/pr-title/action.yml
@@ -30,5 +30,5 @@ inputs:
     default: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
## Description
Now that node12 actions are [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), can this use node16?

## Motivation and Context


## How Has This Been Tested?
¯\\_(ツ)_/¯ 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/353090/197073480-db2e91e2-14cf-4860-81aa-5ce688ffb926.png)
